### PR TITLE
Add a text only version of the email

### DIFF
--- a/emails/daily_email_text.hbs
+++ b/emails/daily_email_text.hbs
@@ -1,0 +1,7 @@
+{{#each items}}
+
+## {{ title }}
+{{#each entries}}
+- {{ title }}<{{ url }}>
+{{/each}}
+{{/each}}

--- a/emails/daily_email_text.hbs
+++ b/emails/daily_email_text.hbs
@@ -2,6 +2,6 @@
 
 ## {{ title }}
 {{#each entries}}
-- {{ title }}<{{ url }}>
+- {{ title }} - {{ url }}
 {{/each}}
 {{/each}}

--- a/paperboy-cli/src/cli.rs
+++ b/paperboy-cli/src/cli.rs
@@ -20,8 +20,10 @@ pub enum Commands {
         email: String,
         /// Subscription file
         subscription_file: String,
-        /// Email template (Using handlebars)
-        template: String,
+        /// Email template as HTML (Using handlebars)
+        template_html: String,
+        /// Email template as text (Using handlebars)
+        template_text: Option<String>,
     },
     // TODO
     // #[clap(subcommand)]

--- a/paperboy-cli/src/deliver.rs
+++ b/paperboy-cli/src/deliver.rs
@@ -16,7 +16,8 @@ pub struct MailConfig<'a> {
 #[derive(Debug)]
 pub struct Deliver<'a> {
     pub subscription_file: &'a str,
-    pub template: &'a str,
+    pub template_html: &'a str,
+    pub template_text: Option<&'a str>,
     pub mail_config: MailConfig<'a>,
 }
 
@@ -28,9 +29,10 @@ pub struct DeliverResult {
 }
 
 impl<'a> Deliver<'a> {
-    pub fn new(subscription_file: &'a str, template: &'a str, mail_config: MailConfig<'a>) -> Self {
+    pub fn new(subscription_file: &'a str, template_html: &'a str, template_text: Option<&'a str>, mail_config: MailConfig<'a>) -> Self {
         Self {
-            template,
+            template_html,
+            template_text,
             subscription_file,
             mail_config,
         }
@@ -56,7 +58,7 @@ impl<'a> Deliver<'a> {
 
         match FeedLoader::new(subscriptions).load().await {
             Some((items, error_result)) => {
-                Paperboy::new(self.template, mailer_config)
+                Paperboy::new(self.template_html, self.template_text, mailer_config)
                     .deliver(items, to.to_string())
                     .await?;
 

--- a/paperboy-cli/src/main.rs
+++ b/paperboy-cli/src/main.rs
@@ -25,7 +25,8 @@ async fn main() -> Result<()> {
         Commands::Deliver {
             email,
             subscription_file,
-            template,
+            template_html,
+            template_text,
         } => {
             log::trace!("Deliver command");
 
@@ -37,7 +38,7 @@ async fn main() -> Result<()> {
                 std::process::exit(1);
             }
 
-            deliver_rss_by_email(email, subscription_file, template).await?;
+            deliver_rss_by_email(email, subscription_file, template_html, template_text).await?;
         }
     };
 
@@ -47,7 +48,8 @@ async fn main() -> Result<()> {
 async fn deliver_rss_by_email(
     email: String,
     subscription_file: String,
-    template: String,
+    template_html: String,
+    template_text: Option<String>,
 ) -> Result<()> {
     let smtp_port = match option_env!("SMTP_PORT") {
         Some(p) => p.parse::<u16>().unwrap(),
@@ -83,7 +85,7 @@ async fn deliver_rss_by_email(
         smtp_port: &smtp_port,
     };
 
-    let result = Deliver::new(&subscription_file, &template, config)
+    let result = Deliver::new(&subscription_file, &template_html, template_text.as_deref(), config)
         .handle(&email)
         .await?;
 


### PR DESCRIPTION
Fixes #8 

Result: https://www.mail-tester.com/test-j41vnclu5

The text template is not required to be given to the CLI