### PR TITLE
Add Docker Compose with Mailpit for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_USERNAME=paperboy
+SMTP_PASSWORD=paperboy
+SMTP_FROM="Paperboy <paperboy@localhost>"
+SMTP_STARTTLS=false
+EMAIL_SUBJECT="RSS Daily"
+MAIL_TO="reader@localhost"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ SMTP_PORT=2525                             # SMTP port
 SMTP_USERNAME="username"                   # SMTP username
 SMTP_PASSWORD="password"                   # SMTP password
 SMTP_FROM="Paperboy <rss@domain.com>"      # the sender
+SMTP_STARTTLS="true"                       # use STARTTLS (default: true, set to false for local dev)
 MAIL_TO="email@domain.com"                 # the recipient
 EMAIL_SUBJECT="Subject"                    # Email subject (optional)
 ```
@@ -45,13 +46,29 @@ Options:
 ### Deliver command
 
 ```bash
-paperboy deliver email@domain subscriptions.txt template.hbs template_text.hbs
-# Template example.: emails/daily_email.hbs
+paperboy deliver reader@localhost subs_example.txt emails/daily_email.hbs emails/daily_email_text.hbs
 ```
 
 ## GitHub template
 
 If you want an **automatic** and **free** way to receive daily "newspapers" using `paperboy`, take a look at the [paperboy-template](https://github.com/eduardostuart/paperboy-template) GitHub project.
+
+## Local development
+
+Use Docker Compose to run [Mailpit](https://github.com/axllent/mailpit) for local email testing:
+
+```bash
+docker compose up -d
+```
+
+Then configure the environment variables (see `.env.example`):
+
+```bash
+source .env.example
+cargo run -- deliver reader@localhost subs_example.txt emails/daily_email.hbs emails/daily_email_text.hbs
+```
+
+Open `http://localhost:8025` to view the received emails.
 
 ## Tests
 

--- a/crates/paperboy-cli/src/deliver.rs
+++ b/crates/paperboy-cli/src/deliver.rs
@@ -11,6 +11,7 @@ pub struct MailConfig<'a> {
     pub smtp_password: &'a str,
     pub smtp_host: &'a str,
     pub smtp_port: &'a u16,
+    pub smtp_starttls: bool,
 }
 
 #[derive(Debug)]
@@ -58,6 +59,7 @@ impl<'a> Deliver<'a> {
             },
             host: self.mail_config.smtp_host.to_string(),
             port: *self.mail_config.smtp_port,
+            starttls: self.mail_config.smtp_starttls,
         };
 
         log::debug!("Fetching latest posts from all subscriptions...");

--- a/crates/paperboy-cli/src/main.rs
+++ b/crates/paperboy-cli/src/main.rs
@@ -51,10 +51,13 @@ async fn deliver_rss_by_email(
     template_html: String,
     template_text: Option<String>,
 ) -> Result<()> {
-    let smtp_port = match option_env!("SMTP_PORT") {
-        Some(p) => p.parse::<u16>().unwrap(),
-        None => 25,
-    };
+    let smtp_port = get_env_key("SMTP_PORT", Some("25"), "")
+        .parse::<u16>()
+        .expect("[Error] - SMTP_PORT must be a valid port number");
+
+    let smtp_starttls = get_env_key("SMTP_STARTTLS", Some("true"), "")
+        .to_lowercase()
+        != "false";
 
     let config = MailConfig {
         mail_subject: &get_env_key(
@@ -83,6 +86,7 @@ async fn deliver_rss_by_email(
             "[Error] - SMTP_USERNAME environment variable is not defined",
         ),
         smtp_port: &smtp_port,
+        smtp_starttls,
     };
 
     let result = Deliver::new(

--- a/crates/paperboy/src/mailer.rs
+++ b/crates/paperboy/src/mailer.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub host: String,
     pub port: u16,
     pub credentials: Credentials,
+    pub starttls: bool,
 }
 
 #[derive(Debug)]
@@ -65,13 +66,23 @@ impl Mailer {
             .multipart(parts)
             .unwrap();
 
-        let transport = SmtpTransport::starttls_relay(&self.config.host)
-            .unwrap()
-            .credentials(LettreCredentials::new(
-                self.config.credentials.username.clone(),
-                self.config.credentials.password.clone(),
-            ))
-            .build();
+        let creds = LettreCredentials::new(
+            self.config.credentials.username.clone(),
+            self.config.credentials.password.clone(),
+        );
+
+        let transport = if self.config.starttls {
+            SmtpTransport::starttls_relay(&self.config.host)
+                .unwrap()
+                .port(self.config.port)
+                .credentials(creds)
+                .build()
+        } else {
+            SmtpTransport::builder_dangerous(&self.config.host)
+                .port(self.config.port)
+                .credentials(creds)
+                .build()
+        };
 
         Ok(transport.send(&email)?)
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "${MAILPIT_SMTP_PORT:-1025}:1025"
+      - "${MAILPIT_UI_PORT:-8025}:8025"
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1

--- a/subs_example.txt
+++ b/subs_example.txt
@@ -1,0 +1,1 @@
+https://hnrss.org/newest?count=5


### PR DESCRIPTION
## Summary
- Add Mailpit via Docker Compose for local email testing
- Add SMTP_STARTTLS option (set to `false` for local dev)
- Fix SMTP_PORT to use runtime env var
- Add `.env.example` and `subs_example.txt`
- Update README with local development section

Depends on #16

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>