### PR TITLE
Test JSON Feed support, drop docs.rs references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,5 @@ readme = "./README.md"
 homepage = "https://github.com/eduardostuart/paperboy"
 repository = "https://github.com/eduardostuart/paperboy.git"
 description = "Get new posts from all your favorite sites by email."
-documentation = "https://docs.rs/paperboy"
 license = "MIT"
 keywords = ["rss", "feed", "rss-reader"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A CLI that mails you every fresh post from your RSS, Atom, and JSON feed subscri
 - Renders the digest through a Handlebars HTML template (plus an optional plain-text alternative)
 - Delivers through any SMTP relay and pairs with the [paperboy-template](https://github.com/eduardostuart/paperboy-template) GitHub Action for fully automated daily delivery
 
-[`download`](https://github.com/eduardostuart/paperboy/releases/latest) · [`docs.rs`](https://docs.rs/paperboy) · [`development & usage`](./docs/DEVELOPMENT.md) · [`license`](./LICENSE-MIT)
+[`download`](https://github.com/eduardostuart/paperboy/releases/latest) · [`development & usage`](./docs/DEVELOPMENT.md) · [`license`](./LICENSE-MIT)
 
 <br clear="both" />
 

--- a/crates/paperboy/Cargo.toml
+++ b/crates/paperboy/Cargo.toml
@@ -2,7 +2,6 @@
 name = "paperboy"
 version = "0.1.3"
 description = "Get new posts from all your favorite sites by email."
-documentation = "https://docs.rs/paperboy"
 keywords.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/crates/paperboy/src/rss.rs
+++ b/crates/paperboy/src/rss.rs
@@ -332,6 +332,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_parses_json_feed_and_keeps_fresh_items() {
+        let mut server = mockito::Server::new_async().await;
+        let body = format!(
+            r#"{{
+    "version": "https://jsonfeed.org/version/1.1",
+    "title": "My JSON Feed",
+    "home_page_url": "http://example.com/",
+    "feed_url": "http://example.com/feed.json",
+    "items": [
+        {{
+            "id": "1",
+            "title": "Today JSON Post",
+            "url": "http://example.com/today",
+            "date_published": "{}"
+        }},
+        {{
+            "id": "2",
+            "title": "Old JSON Post",
+            "url": "http://example.com/old",
+            "date_published": "2020-01-01T00:00:00Z"
+        }}
+    ]
+}}"#,
+            Utc::now().to_rfc3339()
+        );
+        let _m = server
+            .mock("GET", "/feed.json")
+            .with_status(200)
+            .with_header("content-type", "application/feed+json")
+            .with_body(&body)
+            .create_async()
+            .await;
+
+        let feed = Feed::new(format!("{}/feed.json", server.url()))
+            .fetch()
+            .await
+            .unwrap();
+        assert_eq!(feed.title, "My JSON Feed");
+        assert_eq!(feed.entries.len(), 1);
+        assert_eq!(feed.entries[0].title, "Today JSON Post");
+        assert!(feed.entries[0].url.starts_with("http://example.com/today"));
+    }
+
+    #[tokio::test]
     async fn fetch_falls_back_to_url_when_feed_has_no_title() {
         // Regression: previous version called result.title.unwrap()
         let mut server = mockito::Server::new_async().await;


### PR DESCRIPTION
## Summary
- **test**: mockito-backed test that serves a JSON Feed 1.1 body with one fresh and one old item, confirming the README's claim that JSON Feed subscriptions work end-to-end (parsing + 24h filter)
- **docs**: drop `docs.rs` link from the README and the `documentation = "https://docs.rs/paperboy"` entry from `Cargo.toml` - the crate isn't published to crates.io

## Test plan
- [x] `cargo test --all` (20 passing, up from 19)
- [x] `cargo build --all` (clean)

Generated with [Claude Code](https://claude.com/claude-code)