### PR TITLE
Bump paperboy-cli to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "paperboy-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/crates/paperboy-cli/Cargo.toml
+++ b/crates/paperboy-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperboy-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Paperboy CLI"
 


### PR DESCRIPTION
## Summary
Patch bump for `paperboy-cli`: `0.1.7` → `0.1.8`. Reflects the security patches, panic fixes, and added tests merged since the last release. No new features, so no minor bump. Library crate version is unchanged.

## Test plan
- [x] `cargo build --all` (clean)
- [x] `paperboy --version` → `paperboy-cli 0.1.8`

Generated with [Claude Code](https://claude.com/claude-code)