### PR TITLE
Bump paperboy-cli to 0.2.3 (align with release tags)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "paperboy-cli"
-version = "0.1.8"
+version = "0.2.3"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/crates/paperboy-cli/Cargo.toml
+++ b/crates/paperboy-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperboy-cli"
-version = "0.1.8"
+version = "0.2.3"
 edition = "2021"
 description = "Paperboy CLI"
 


### PR DESCRIPTION
## Summary
Bump `paperboy-cli` `0.1.8` → `0.2.3` so the Cargo version matches the release tag scheme. Tags have been ahead of Cargo since `v0.2.0`; this closes the gap so the next release `v0.2.3` and `paperboy --version` line up.

## Test plan
- [x] `cargo build --all` (clean)
- [x] `paperboy --version` → `paperboy-cli 0.2.3`

Generated with [Claude Code](https://claude.com/claude-code)